### PR TITLE
Add nullable enum support, fix Symfony 7.3 Psalm warnings, and correct class property definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Total Downloads](https://poser.pugx.org/spiral/json-schema-generator/downloads)](https://packagist.org/packages/spiral/json-schema-generator)
 [![psalm-level](https://shepherd.dev/github/spiral/json-schema-generator/level.svg)](https://shepherd.dev/github/spiral/json-schema-generator)
 
-The JSON Schema Generator is a PHP package that simplifies the generation of [JSON schemas](https://json-schema.org/) from Data Transfer Object (DTO) classes. 
+The JSON Schema Generator is a PHP package that simplifies the generation of [JSON schemas](https://json-schema.org/) from Data Transfer Object (DTO) classes.
 It supports PHP enumerations and generic type annotations for arrays and provides an attribute for specifying title, description, and default value.
 
 Main use case - structured output definition for LLMs.
@@ -107,38 +107,21 @@ Example array output:
         'description'   => [
             'title'       => 'Description',
             'description' => 'The description of the movie',
-            'type'        => 'string',
+            'type'        => ['string', 'null'],
         ],
         'director'      => [
-            'type' => 'string',
+            'type' => ['string', 'null'],
         ],
         'releaseStatus' => [
             'title'       => 'Release Status',
             'description' => 'The release status of the movie',
-            'allOf'       => [
-                [
-                    '$ref' => '#/definitions/ReleaseStatus',
-                ],
-            ],
+            'type'        => ['string', 'null']
+            'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
         ],
     ],
     'required'    => [
         'title',
         'year',
-    ],
-    'definitions' => [
-        'ReleaseStatus' => [
-            'title' => 'ReleaseStatus',
-            'type'  => 'string',
-            'enum'  => [
-                'Released',
-                'Rumored',
-                'Post Production',
-                'In Production',
-                'Planned',
-                'Canceled',
-            ],
-        ],
     ],
 ];
 ```
@@ -160,6 +143,7 @@ final class Actor
          * @var array<Movie>
          */
         public readonly array $movies = [],
+        public readonly ?Movie $bestMovie = null;
     ) {
     }
 }
@@ -197,6 +181,18 @@ Example array output:
             ],
             'default' => [],
         ],
+        'bestMovie' => [
+            'title'       => 'Best Movie',
+            'description' => 'The best movie of the actor',
+            'oneOf'       => [
+                [
+                    '$ref' => '#/definitions/Movie',
+                ],
+                [
+                    'type' => 'null',
+                ],
+            ],
+        ],
     ],
     'required'   => [
         'name',
@@ -219,19 +215,16 @@ Example array output:
                 'description'   => [
                     'title'       => 'Description',
                     'description' => 'The description of the movie',
-                    'type'        => 'string',
+                    'type'        => ['string', 'null'],
                 ],
                 'director'      => [
-                    'type' => 'string',
+                    'type' => ['string', 'null'],
                 ],
                 'releaseStatus' => [
                     'title'       => 'Release Status',
                     'description' => 'The release status of the movie',
-                    'allOf'       => [
-                        [
-                            '$ref' => '#/definitions/ReleaseStatus',
-                        ],
-                    ],
+                    'type'        => ['string', 'null']
+                    'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                 ],
             ],
             'required'   => [
@@ -239,18 +232,6 @@ Example array output:
                 'year',
             ],
         ],
-        'ReleaseStatus' => [
-            'title' => 'ReleaseStatus',
-            'type'  => 'string',
-            'enum'  => [
-                'Released',
-                'Rumored',
-                'Post Production',
-                'In Production',
-                'Planned',
-                'Canceled',
-            ],
-       ]
     ],
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -107,16 +107,36 @@ Example array output:
         'description'   => [
             'title'       => 'Description',
             'description' => 'The description of the movie',
-            'type'        => ['string', 'null'],
+            'oneOf'       => [
+                ['type' => 'null'],
+                ['type' => 'string'],
+            ],
         ],
-        'director'      => [
-            'type' => ['string', 'null'],
+        'director' => [
+            'oneOf' => [
+                ['type' => 'null'],
+                ['type' => 'string'],
+            ],
         ],
         'releaseStatus' => [
             'title'       => 'Release Status',
             'description' => 'The release status of the movie',
-            'type'        => ['string', 'null']
-            'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+            'oneOf'       => [
+                [
+                    'type' => 'null',
+                ],
+                [
+                    'type' => 'string',
+                    'enum' => [
+                        'Released',
+                        'Rumored',
+                        'Post Production',
+                        'In Production',
+                        'Planned',
+                        'Canceled',
+                    ],
+                ],
+            ],
         ],
     ],
     'required'    => [
@@ -142,7 +162,7 @@ final class Actor
         /**
          * @var array<Movie>
          */
-        public readonly array $movies = [],
+        public readonly ?array $movies = null,
         public readonly ?Movie $bestMovie = null;
     ) {
     }
@@ -175,21 +195,27 @@ Example array output:
             'type' => 'string',
         ],
         'movies' => [
-            'type'  => 'array',
-            'items' => [
-                '$ref' => '#/definitions/Movie',
+            'oneOf' => [
+                [
+                    'type' => 'null',
+                ],
+                [
+                    'type'  => 'array',
+                    'items' => [
+                        '$ref' => '#/definitions/Movie',
+                    ],
+                ],
             ],
-            'default' => [],
         ],
         'bestMovie' => [
             'title'       => 'Best Movie',
             'description' => 'The best movie of the actor',
             'oneOf'       => [
                 [
-                    '$ref' => '#/definitions/Movie',
+                    'type' => 'null',
                 ],
                 [
-                    'type' => 'null',
+                    '$ref' => '#/definitions/Movie',
                 ],
             ],
         ],
@@ -215,15 +241,24 @@ Example array output:
                 'description'   => [
                     'title'       => 'Description',
                     'description' => 'The description of the movie',
-                    'type'        => ['string', 'null'],
+                    'oneOf'       => [
+                        ['type' => 'null'],
+                        ['type' => 'string'],
+                    ],
                 ],
                 'director'      => [
-                    'type' => ['string', 'null'],
+                    'oneOf' => [
+                        ['type' => 'null'],
+                        ['type' => 'string'],
+                    ],
                 ],
                 'releaseStatus' => [
                     'title'       => 'Release Status',
                     'description' => 'The release status of the movie',
-                    'type'        => ['string', 'null']
+                    'oneOf'       => [
+                        ['type' => 'null'],
+                        ['type' => 'string'],
+                    ],
                     'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                 ],
             ],
@@ -235,6 +270,163 @@ Example array output:
     ],
 ];
 ```
+
+## Polymorphic Arrays (anyOf)
+The generator also supports arrays that contain different types of DTOs using PHPDoc annotations like **@var list<Movie|Series>**.
+For example, if an actor can have a filmography that includes both movies and TV series, you can define it like this:
+```php
+namespace App\DTO;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final class Actor
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $age,
+
+        #[Field(title: 'Biography', description: 'The biography of the actor')]
+        public readonly ?string $bio = null,
+
+        /**
+         * @var list<Movie|Series>|null
+         */
+        #[Field(title: 'Filmography', description: 'List of movies and series featuring the actor')]
+        public readonly ?array $filmography = null,
+
+        #[Field(title: 'Best Movie', description: 'The best movie of the actor')]
+        public readonly ?Movie $bestMovie = null,
+
+        #[Field(title: 'Best Series', description: 'The most prominent series of the actor')]
+        public readonly ?Series $bestSeries = null,
+    ) {}
+}
+```
+The generated schema will reflect this with an anyOf definition in the items section:
+```php
+[
+    'properties' => [
+        'filmography' => [
+            'title'       => 'Filmography',
+            'description' => 'List of movies and series featuring the actor',
+            'oneOf'       => [
+                ['type' => 'null'],
+                [
+                    'type'  => 'array',
+                    'items' => [
+                        'anyOf' => [
+                            ['$ref' => '#/definitions/Movie'],
+                            ['$ref' => '#/definitions/Series'],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'definitions' => [
+        'Movie'  => [/* ... */],
+        'Series' => [/* ... */],
+    ],
+];
+```
+## Example DTO: Series
+Here's what the Series class might look like:
+```php
+namespace App\DTO;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+use Spiral\JsonSchemaGenerator\Attribute\Format;
+
+final class Series
+{
+    public function __construct(
+        #[Field(title: 'Title', description: 'The title of the series')]
+        public readonly string $title,
+
+        #[Field(title: 'First Air Year', description: 'The year the series first aired')]
+        public readonly int $firstAirYear,
+
+        #[Field(title: 'Description', description: 'The description of the series')]
+        public readonly ?string $description = null,
+
+        #[Field(title: 'Creator', description: 'The creator or showrunner of the series')]
+        public readonly ?string $creator = null,
+
+        #[Field(title: 'Series Status', description: 'The current status of the series')]
+        public readonly ?SeriesStatus $status = null,
+
+        #[Field(title: 'First Air Date', description: 'The original release date of the series', format: Format::Date)]
+        public readonly ?string $firstAirDate = null,
+
+        #[Field(title: 'Last Air Date', description: 'The most recent air date of the series', format: Format::Date)]
+        public readonly ?string $lastAirDate = null,
+
+        #[Field(title: 'Seasons', description: 'Number of seasons released')]
+        public readonly ?int $seasons = null,
+    ) {}
+}
+```
+> **Note**
+> When using polymorphic arrays, make sure all referenced DTOs (e.g., Movie, Series)
+> are also annotated properly so their definitions can be generated correctly.
+
+## Union Types
+The JSON Schema Generator supports native PHP union types (introduced in PHP 8.0), including nullable and multi-type definitions.
+Here's an example DTO using union types:
+```php
+namespace App\DTO;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final class FlexibleValue
+{
+    public function __construct(
+        #[Field(title: 'Value', description: 'Can be either string or integer')]
+        public readonly string|int $value,
+
+        #[Field(title: 'Optional Flag', description: 'Boolean or null')]
+        public readonly bool|null $flag = null,
+
+        #[Field(title: 'Flexible Field', description: 'Can be string, int, or null')]
+        public readonly string|int|null $flex = null,
+    ) {}
+}
+```
+The generated schema will include a `oneOf` section to reflect the union types:
+```php
+[
+    'properties' => [
+        'value' => [
+            'title'       => 'Value',
+            'description' => 'Can be either string or integer',
+            'oneOf'       => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ],
+        'flag' => [
+            'title'       => 'Optional Flag',
+            'description' => 'Boolean or null',
+            'oneOf'       => [
+                ['type' => 'null'],
+                ['type' => 'boolean'],
+            ],
+        ],
+        'flex' => [
+            'title'       => 'Flexible Field',
+            'description' => 'Can be string, int, or null',
+            'oneOf'       => [
+                ['type' => 'null'],
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+        ],
+    ],
+    'required' => ['value'],
+]
+```
+> **Note**
+> All supported types are automatically resolved from native PHP type declarations and reflected in the JSON Schema output using oneOf.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/property-info": "^6.4.18 || ^7.2.0 <7.3",
+        "symfony/property-info": "^6.4.18 || ^7.2.0",
         "phpstan/phpdoc-parser": "^1.33 | ^2.1",
         "phpdocumentor/reflection-docblock": "^5.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/property-info": "^6.4.18 || ^7.2",
+        "symfony/property-info": "^6.4.18 || ^7.2.0 <7.3",
         "phpstan/phpdoc-parser": "^1.33 | ^2.1",
         "phpdocumentor/reflection-docblock": "^5.3"
     },

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -83,14 +83,6 @@ class Generator implements GeneratorInterface
     protected function generateDefinition(ClassParserInterface $class, array &$dependencies = []): ?Definition
     {
         $properties = [];
-        if ($class->isEnum()) {
-            return new Definition(
-                type: $class->getName(),
-                options: $class->getEnumValues(),
-                title: $class->getShortName(),
-            );
-        }
-
         // class properties
         foreach ($class->getProperties() as $property) {
             $psc = $this->generateProperty($property);
@@ -137,14 +129,33 @@ class Generator implements GeneratorInterface
 
         $required = $default === null && !$type->allowsNull();
         if ($type->isBuiltin()) {
-            return new Property($type->getName(), $options, $title, $description, $required, $default, $format);
+            return new Property(
+                type: $type->getName(),
+                options: $options,
+                title: $title,
+                description: $description,
+                required: $required,
+                allowsNull: $type->allowsNull(),
+                default: $default,
+                enum: $type->getEnumValues(),
+                format: $format,
+            );
         }
 
-        // Class or enum
+        // Class
         $class = $type->getName();
 
         return \is_string($class) && \class_exists($class)
-            ? new Property($class, [], $title, $description, $required, $default, $format)
+            ? new Property(
+                type: $class,
+                options: [],
+                title: $title,
+                description: $description,
+                required: $required,
+                allowsNull: $type->allowsNull(),
+                default: $default,
+                format: $format,
+            )
             : null;
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -9,9 +9,11 @@ use Spiral\JsonSchemaGenerator\Parser\ClassParserInterface;
 use Spiral\JsonSchemaGenerator\Parser\Parser;
 use Spiral\JsonSchemaGenerator\Parser\ParserInterface;
 use Spiral\JsonSchemaGenerator\Parser\PropertyInterface;
-use Spiral\JsonSchemaGenerator\Parser\TypeInterface;
+use Spiral\JsonSchemaGenerator\Parser\SimpleType;
+use Spiral\JsonSchemaGenerator\Parser\Type;
 use Spiral\JsonSchemaGenerator\Schema\Definition;
 use Spiral\JsonSchemaGenerator\Schema\Property;
+use Spiral\JsonSchemaGenerator\Schema\PropertyType;
 
 class Generator implements GeneratorInterface
 {
@@ -119,43 +121,28 @@ class Generator implements GeneratorInterface
 
         $type = $property->getType();
 
-        $options = [];
-        if ($property->isCollection()) {
-            $options = \array_map(
-                static fn(TypeInterface $type) => $type->getName(),
-                $property->getCollectionValueTypes(),
-            );
-        }
+        return new Property(
+            types: $this->extractPropertyTypes($type),
+            title: $title,
+            description: $description,
+            required: $default === null && !$type->allowsNull(),
+            default: $default,
+            format: $format,
+        );
+    }
 
-        $required = $default === null && !$type->allowsNull();
-        if ($type->isBuiltin()) {
-            return new Property(
-                type: $type->getName(),
-                options: $options,
-                title: $title,
-                description: $description,
-                required: $required,
-                allowsNull: $type->allowsNull(),
-                default: $default,
-                enum: $type->getEnumValues(),
-                format: $format,
-            );
-        }
-
-        // Class
-        $class = $type->getName();
-
-        return \is_string($class) && \class_exists($class)
-            ? new Property(
-                type: $class,
-                options: [],
-                title: $title,
-                description: $description,
-                required: $required,
-                allowsNull: $type->allowsNull(),
-                default: $default,
-                format: $format,
-            )
-            : null;
+    /**
+     * @return list<PropertyType>
+     */
+    private function extractPropertyTypes(Type $type): array
+    {
+        return \array_map(static fn(SimpleType $simpleType) => new PropertyType(
+            type: $simpleType->getName(),
+            enum: $simpleType->getEnumValues(),
+            collectionTypes: $simpleType->isCollection() ? \array_map(static fn(SimpleType $collectionSimpleType) => new PropertyType(
+                type: $collectionSimpleType->getName(),
+                enum: $collectionSimpleType->getEnumValues(),
+            ), $simpleType->getCollectionType()?->types ?? []) : null,
+        ), $type->types);
     }
 }

--- a/src/Parser/ClassParser.php
+++ b/src/Parser/ClassParser.php
@@ -88,7 +88,12 @@ final class ClassParser implements ClassParserInterface
 
             $properties[] = new Property(
                 property: $property,
-                type: new Type(name: $type->getName(), builtin: $type->isBuiltin(), nullable: $type->allowsNull()),
+                type: new Type(
+                    name: $this->getTypeName($type),
+                    builtin: $this->getTypeBuildIn($type),
+                    nullable: $type->allowsNull(),
+                    enum: $this->getEnumValues($type),
+                ),
                 hasDefaultValue: $this->hasPropertyDefaultValue($property),
                 defaultValue: $this->getPropertyDefaultValue($property),
                 collectionValueTypes: $this->getPropertyCollectionTypes($property->getName()),
@@ -103,21 +108,47 @@ final class ClassParser implements ClassParserInterface
         return $this->class->isEnum();
     }
 
-    public function getEnumValues(): array
+    private function getEnumValues(\ReflectionNamedType $type): ?array
     {
-        if (!$this->isEnum()) {
-            throw new GeneratorException(\sprintf('Class `%s` is not an enum.', $this->class->getName()));
+        if (!\is_subclass_of($type->getName(), \BackedEnum::class)) {
+            return null;
         }
 
-        $values = [];
-        foreach ($this->class->getReflectionConstants() as $constant) {
-            $value = $constant->getValue();
-            \assert($value instanceof \BackedEnum);
+        $reflectionEnum = new \ReflectionEnum($type->getName());
 
-            $values[] = $value->value;
+        return \array_map(
+            static fn(\ReflectionEnumUnitCase $case): int|string => $case->getValue()->value,
+            $reflectionEnum->getCases(),
+        );
+    }
+
+    private function getTypeBuildIn(\ReflectionNamedType $type): bool
+    {
+        if ($type->isBuiltin() || \is_subclass_of($type->getName(), \BackedEnum::class)) {
+            return true;
         }
 
-        return $values;
+        return false;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function getTypeName(\ReflectionNamedType $type): string
+    {
+        $typeName = $type->getName();
+        if ($type->isBuiltin() || !\is_subclass_of($typeName, \BackedEnum::class)) {
+            return $typeName;
+        }
+
+        $reflection = new \ReflectionEnum($typeName);
+        $backingType = $reflection->getBackingType();
+
+        if (!$backingType instanceof \ReflectionNamedType) {
+            return $typeName;
+        }
+
+        return $backingType->getName();
     }
 
     /**

--- a/src/Parser/ClassParser.php
+++ b/src/Parser/ClassParser.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Spiral\JsonSchemaGenerator\Parser;
 
 use Spiral\JsonSchemaGenerator\Exception\GeneratorException;
+use Spiral\JsonSchemaGenerator\Exception\InvalidTypeException;
 use Spiral\JsonSchemaGenerator\Schema\Type as SchemaType;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type as PropertyInfoType;
 
 /**
  * @internal
@@ -42,10 +44,12 @@ final class ClassParser implements ClassParserInterface
         $this->class = $class;
         $this->propertyInfo = $this->createPropertyInfo();
 
-        if ($this->class->hasMethod('__construct')) {
-            $constructor = $this->class->getMethod('__construct');
+        $constructor = $this->class->getConstructor();
+        if ($constructor !== null) {
             foreach ($constructor->getParameters() as $parameter) {
-                $this->constructorParameters[$parameter->getName()] = $parameter;
+                if ($parameter->isPromoted()) {
+                    $this->constructorParameters[$parameter->getName()] = $parameter;
+                }
             }
         }
     }
@@ -79,24 +83,18 @@ final class ClassParser implements ClassParserInterface
             }
 
             /**
-             * @var \ReflectionNamedType|null $type
+             * @var \ReflectionNamedType|\ReflectionUnionType|null $type
              */
             $type = $property->getType();
-            if (!$type instanceof \ReflectionNamedType) {
+            if (!$type instanceof \ReflectionNamedType && !$type instanceof \ReflectionUnionType) {
                 continue;
             }
 
             $properties[] = new Property(
                 property: $property,
-                type: new Type(
-                    name: $this->getTypeName($type),
-                    builtin: $this->getTypeBuildIn($type),
-                    nullable: $type->allowsNull(),
-                    enum: $this->getEnumValues($type),
-                ),
+                type: $this->getPropertyType($property),
                 hasDefaultValue: $this->hasPropertyDefaultValue($property),
                 defaultValue: $this->getPropertyDefaultValue($property),
-                collectionValueTypes: $this->getPropertyCollectionTypes($property->getName()),
             );
         }
 
@@ -108,13 +106,18 @@ final class ClassParser implements ClassParserInterface
         return $this->class->isEnum();
     }
 
-    private function getEnumValues(\ReflectionNamedType $type): ?array
+    /**
+     * @param non-empty-string|class-string $typeName
+     *
+     * @return list<int|string>|null
+     */
+    private function getEnumValues(string $typeName): ?array
     {
-        if (!\is_subclass_of($type->getName(), \BackedEnum::class)) {
+        if (!\is_subclass_of($typeName, \BackedEnum::class)) {
             return null;
         }
 
-        $reflectionEnum = new \ReflectionEnum($type->getName());
+        $reflectionEnum = new \ReflectionEnum($typeName);
 
         return \array_map(
             static fn(\ReflectionEnumUnitCase $case): int|string => $case->getValue()->value,
@@ -122,22 +125,26 @@ final class ClassParser implements ClassParserInterface
         );
     }
 
-    private function getTypeBuildIn(\ReflectionNamedType $type): bool
+    /**
+     * @param non-empty-string $typeName
+     */
+    private function getTypeBuildIn(string $typeName): bool
     {
-        if ($type->isBuiltin() || \is_subclass_of($type->getName(), \BackedEnum::class)) {
-            return true;
+        if ((\class_exists($typeName))) {
+            return \is_subclass_of($typeName, \BackedEnum::class);
         }
 
-        return false;
+        return $typeName !== SchemaType::Object->value;
     }
 
     /**
-     * @return non-empty-string
+     * @param non-empty-string|class-string $typeName
+     *
+     * @return non-empty-string|class-string
      */
-    private function getTypeName(\ReflectionNamedType $type): string
+    private function getEnumTypeName(string $typeName): string
     {
-        $typeName = $type->getName();
-        if ($type->isBuiltin() || !\is_subclass_of($typeName, \BackedEnum::class)) {
+        if (!\is_subclass_of($typeName, \BackedEnum::class)) {
             return $typeName;
         }
 
@@ -151,39 +158,68 @@ final class ClassParser implements ClassParserInterface
         return $backingType->getName();
     }
 
-    /**
-     * @param non-empty-string $property
-     *
-     * @return array<TypeInterface>
-     */
-    private function getPropertyCollectionTypes(string $property): array
+    private function getPropertyType(\ReflectionProperty $property): Type
     {
-        $types = $this->propertyInfo->getTypes($this->class->getName(), $property);
+        /** @psalm-suppress DeprecatedMethod, DeprecatedClass */
+        $types = $this->propertyInfo->getTypes($property->class, $property->getName());
 
-        $collectionTypes = [];
+        $simpleTypes = [];
+        $isNullable = false;
         foreach ($types ?? [] as $type) {
-            if ($type->isCollection()) {
-                $collectionTypes = [...$type->getCollectionValueTypes(), ...$collectionTypes];
-            }
-        }
-
-        $result = [];
-        foreach ($collectionTypes as $type) {
-            /**
-             * @var non-empty-string $name
-             */
-            $name = $type->getBuiltinType() === SchemaType::Object->value
+            $typeName = $type->getBuiltinType() === SchemaType::Object->value && $type->getClassName() !== null
                 ? $type->getClassName()
                 : $type->getBuiltinType();
 
-            $result[] = new Type(
-                name: $name,
-                builtin: $type->getBuiltinType() !== SchemaType::Object->value,
-                nullable: $type->isNullable(),
+            if ($typeName === '') {
+                throw new InvalidTypeException();
+            }
+            if ($type->isNullable() && $isNullable === false) {
+                $simpleTypes[] = new SimpleType(
+                    name: SchemaType::Null->value,
+                    builtin: true,
+                );
+                $isNullable = true;
+            }
+
+            $simpleTypes[] = new SimpleType(
+                name: $this->getEnumTypeName($typeName),
+                builtin: $this->getTypeBuildIn($typeName),
+                collectionType: $this->getCollectionValueType($type),
+                enum: $this->getEnumValues($typeName),
             );
         }
 
-        return $result;
+        return new Type(types: $simpleTypes);
+    }
+
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
+    private function getCollectionValueType(PropertyInfoType $propertyInfoType): ?Type
+    {
+        if (!$propertyInfoType->isCollection()) {
+            return null;
+        }
+
+        $simpleTypes = [];
+        /** @psalm-suppress DeprecatedClass */
+        foreach ($propertyInfoType->getCollectionValueTypes() as $collectionValueType) {
+            $typeName = $collectionValueType->getBuiltinType() === SchemaType::Object->value && $collectionValueType->getClassName() !== null
+                ? $collectionValueType->getClassName()
+                : $collectionValueType->getBuiltinType();
+
+            if ($typeName === '') {
+                throw new InvalidTypeException();
+            }
+
+            $simpleTypes[] = new SimpleType(
+                name: $this->getEnumTypeName($typeName),
+                builtin: $this->getTypeBuildIn($typeName),
+                enum: $this->getEnumValues($typeName),
+            );
+        }
+
+        return new Type(types: $simpleTypes);
     }
 
     private function hasPropertyDefaultValue(\ReflectionProperty $property): bool

--- a/src/Parser/ClassParserInterface.php
+++ b/src/Parser/ClassParserInterface.php
@@ -20,8 +20,4 @@ interface ClassParserInterface
      * @return array<PropertyInterface>
      */
     public function getProperties(): array;
-
-    public function isEnum(): bool;
-
-    public function getEnumValues(): array;
 }

--- a/src/Parser/Property.php
+++ b/src/Parser/Property.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Spiral\JsonSchemaGenerator\Parser;
 
-use Spiral\JsonSchemaGenerator\Schema\Type as SchemaType;
-
 /**
  * @internal
  */
@@ -13,10 +11,9 @@ final class Property implements PropertyInterface
 {
     public function __construct(
         private readonly \ReflectionProperty $property,
-        private readonly TypeInterface $type,
+        private readonly Type $type,
         private readonly bool $hasDefaultValue,
         private readonly mixed $defaultValue = null,
-        private readonly array $collectionValueTypes = [],
     ) {}
 
     /**
@@ -54,25 +51,7 @@ final class Property implements PropertyInterface
         return $this->defaultValue;
     }
 
-    public function isCollection(): bool
-    {
-        $type = $this->type->getName();
-        if (!$type instanceof SchemaType) {
-            return false;
-        }
-
-        return $type->value === SchemaType::Array->value;
-    }
-
-    /**
-     * @return array<TypeInterface>
-     */
-    public function getCollectionValueTypes(): array
-    {
-        return $this->collectionValueTypes;
-    }
-
-    public function getType(): TypeInterface
+    public function getType(): Type
     {
         return $this->type;
     }

--- a/src/Parser/PropertyInterface.php
+++ b/src/Parser/PropertyInterface.php
@@ -24,12 +24,5 @@ interface PropertyInterface
 
     public function getDefaultValue(): mixed;
 
-    public function isCollection(): bool;
-
-    /**
-     * @return array<TypeInterface>
-     */
-    public function getCollectionValueTypes(): array;
-
-    public function getType(): TypeInterface;
+    public function getType(): Type;
 }

--- a/src/Parser/SimpleType.php
+++ b/src/Parser/SimpleType.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\JsonSchemaGenerator\Parser;
+
+use Spiral\JsonSchemaGenerator\Schema\Type as SchemaType;
+
+/**
+ * @internal
+ */
+final class SimpleType implements TypeInterface
+{
+    /**
+     * @var class-string|SchemaType
+     */
+    private string|SchemaType $name;
+
+    /**
+     * @param non-empty-string|class-string $name
+     * @param list<int|string>|null $enum
+     */
+    public function __construct(
+        string $name,
+        private readonly bool $builtin,
+        private readonly ?Type $collectionType = null,
+        private readonly ?array $enum = null,
+    ) {
+        /** @psalm-suppress PropertyTypeCoercion */
+        $this->name = $this->builtin ? SchemaType::fromBuiltIn($name) : $name;
+    }
+
+    /**
+     * @return class-string|SchemaType
+     */
+    public function getName(): string|SchemaType
+    {
+        return $this->name;
+    }
+
+    public function isBuiltin(): bool
+    {
+        return $this->builtin;
+    }
+
+    public function isEnum(): bool
+    {
+        return $this->enum !== null;
+    }
+
+    /**
+     * @return list<int|string>|null
+     */
+    public function getEnumValues(): ?array
+    {
+        return $this->enum;
+    }
+
+    public function isCollection(): bool
+    {
+        return $this->collectionType !== null;
+    }
+
+    public function getCollectionType(): ?Type
+    {
+        return $this->collectionType;
+    }
+}

--- a/src/Parser/Type.php
+++ b/src/Parser/Type.php
@@ -23,6 +23,7 @@ final class Type implements TypeInterface
         string $name,
         private readonly bool $builtin,
         private readonly bool $nullable,
+        private readonly ?array $enum = null,
     ) {
         /** @psalm-suppress PropertyTypeCoercion */
         $this->name = $this->builtin ? SchemaType::fromBuiltIn($name) : $name;
@@ -44,5 +45,15 @@ final class Type implements TypeInterface
     public function allowsNull(): bool
     {
         return $this->nullable;
+    }
+
+    public function isEnum(): bool
+    {
+        return $this->enum !== null;
+    }
+
+    public function getEnumValues(): ?array
+    {
+        return $this->enum;
     }
 }

--- a/src/Parser/Type.php
+++ b/src/Parser/Type.php
@@ -9,51 +9,17 @@ use Spiral\JsonSchemaGenerator\Schema\Type as SchemaType;
 /**
  * @internal
  */
-final class Type implements TypeInterface
+final class Type
 {
     /**
-     * @var class-string|SchemaType
-     */
-    private string|SchemaType $name;
-
-    /**
-     * @param non-empty-string|class-string $name
+     * @param list<SimpleType> $types
      */
     public function __construct(
-        string $name,
-        private readonly bool $builtin,
-        private readonly bool $nullable,
-        private readonly ?array $enum = null,
-    ) {
-        /** @psalm-suppress PropertyTypeCoercion */
-        $this->name = $this->builtin ? SchemaType::fromBuiltIn($name) : $name;
-    }
-
-    /**
-     * @return class-string|SchemaType
-     */
-    public function getName(): string|SchemaType
-    {
-        return $this->name;
-    }
-
-    public function isBuiltin(): bool
-    {
-        return $this->builtin;
-    }
+        public readonly array $types,
+    ) {}
 
     public function allowsNull(): bool
     {
-        return $this->nullable;
-    }
-
-    public function isEnum(): bool
-    {
-        return $this->enum !== null;
-    }
-
-    public function getEnumValues(): ?array
-    {
-        return $this->enum;
+        return \count(\array_filter($this->types, static fn(SimpleType $type): bool => $type->getName() === SchemaType::Null)) !== 0;
     }
 }

--- a/src/Parser/TypeInterface.php
+++ b/src/Parser/TypeInterface.php
@@ -16,4 +16,8 @@ interface TypeInterface
     public function isBuiltin(): bool;
 
     public function allowsNull(): bool;
+
+    public function isEnum(): bool;
+
+    public function getEnumValues(): ?array;
 }

--- a/src/Parser/TypeInterface.php
+++ b/src/Parser/TypeInterface.php
@@ -15,8 +15,6 @@ interface TypeInterface
 
     public function isBuiltin(): bool;
 
-    public function allowsNull(): bool;
-
     public function isEnum(): bool;
 
     public function getEnumValues(): ?array;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -18,7 +18,7 @@ final class Schema extends AbstractDefinition
 
     public function jsonSerialize(): array
     {
-        $schema = $this->renderProperties([]);
+        $schema = $this->renderProperties(['type' => 'object']);
 
         if ($this->definitions !== []) {
             $schema['definitions'] = [];

--- a/src/Schema/Definition.php
+++ b/src/Schema/Definition.php
@@ -63,7 +63,7 @@ final class Definition extends AbstractDefinition
         $rf = new \ReflectionClass($this->type);
         if (!$rf->isEnum()) {
             throw new DefinitionException(\sprintf(
-                'Type `%s` must be a backed enum or class with properties.',
+                'SimpleType `%s` must be a backed enum or class with properties.',
                 $this->type instanceof Type ? $this->type->value : $this->type,
             ));
         }
@@ -73,7 +73,7 @@ final class Definition extends AbstractDefinition
         /** @var \ReflectionEnum $rf */
         if (!$rf->isBacked()) {
             throw new DefinitionException(\sprintf(
-                'Type `%s` is not a backed enum.',
+                'SimpleType `%s` is not a backed enum.',
                 $this->type instanceof Type ? $this->type->value : $this->type,
             ));
         }
@@ -89,7 +89,7 @@ final class Definition extends AbstractDefinition
             'string' => 'string',
             'bool' => 'boolean',
             default => throw new DefinitionException(\sprintf(
-                'Type `%s` is not a backed enum.',
+                'SimpleType `%s` is not a backed enum.',
                 $this->type instanceof Type ? $this->type->value : $this->type,
             )),
         };

--- a/src/Schema/Property.php
+++ b/src/Schema/Property.php
@@ -20,7 +20,9 @@ final class Property implements \JsonSerializable
         public readonly string $title = '',
         public readonly string $description = '',
         public readonly bool $required = false,
+        public readonly bool $allowsNull = false,
         public readonly mixed $default = null,
+        public ?array $enum = null,
         public readonly ?Format $format = null,
     ) {
         if (\is_string($this->type) && !\class_exists($this->type)) {
@@ -57,11 +59,21 @@ final class Property implements \JsonSerializable
 
         if (\is_string($this->type)) {
             // this is nested class
-            $property['allOf'][] = ['$ref' => (new Reference($this->type))->jsonSerialize()];
+            if ($this->allowsNull) {
+                $property['oneOf'][] = ['$ref' => (new Reference($this->type))->jsonSerialize()];
+                $property['oneOf'][] = ['type' => Type::Null->value];
+                return $property;
+            }
+            $property['$ref'] = (new Reference($this->type))->jsonSerialize();
+
             return $property;
         }
 
-        $property['type'] = $this->type->value;
+        $property['type'] = $this->allowsNull ? [$this->type->value, Type::Null->value] : $this->type->value;
+
+        if ($this->enum !== null) {
+            $property['enum'] = $this->enum;
+        }
 
         if ($this->type === Type::Array) {
             if (\count($this->options) === 1) {

--- a/src/Schema/Property.php
+++ b/src/Schema/Property.php
@@ -4,33 +4,19 @@ declare(strict_types=1);
 
 namespace Spiral\JsonSchemaGenerator\Schema;
 
-use Spiral\JsonSchemaGenerator\Exception\InvalidTypeException;
-
 final class Property implements \JsonSerializable
 {
-    public readonly PropertyOptions $options;
-
     /**
-     * @param Type|class-string $type
-     * @param array<class-string|Type> $options
+     * @param list<PropertyType> $types
      */
     public function __construct(
-        public readonly Type|string $type,
-        array $options = [],
+        public readonly array $types,
         public readonly string $title = '',
         public readonly string $description = '',
         public readonly bool $required = false,
-        public readonly bool $allowsNull = false,
         public readonly mixed $default = null,
-        public ?array $enum = null,
         public readonly ?Format $format = null,
-    ) {
-        if (\is_string($this->type) && !\class_exists($this->type)) {
-            throw new InvalidTypeException('Invalid type definition.');
-        }
-
-        $this->options = new PropertyOptions($options);
-    }
+    ) {}
 
     public function jsonSerialize(): array
     {
@@ -51,42 +37,13 @@ final class Property implements \JsonSerializable
             $property['format'] = $this->format->value;
         }
 
-
-        if ($this->type === Type::Union) {
-            $property['anyOf'] = $this->options->jsonSerialize();
-            return $property;
-        }
-
-        if (\is_string($this->type)) {
-            // this is nested class
-            if ($this->allowsNull) {
-                $property['oneOf'][] = ['$ref' => (new Reference($this->type))->jsonSerialize()];
-                $property['oneOf'][] = ['type' => Type::Null->value];
-                return $property;
+        $typesCount = \count($this->types);
+        if ($typesCount > 1) {
+            foreach ($this->types as $type) {
+                $property['oneOf'][] = $this->propertyTypeToDefinition($type);
             }
-            $property['$ref'] = (new Reference($this->type))->jsonSerialize();
-
-            return $property;
-        }
-
-        $property['type'] = $this->allowsNull ? [$this->type->value, Type::Null->value] : $this->type->value;
-
-        if ($this->enum !== null) {
-            $property['enum'] = $this->enum;
-        }
-
-        if ($this->type === Type::Array) {
-            if (\count($this->options) === 1) {
-                if (\is_string($this->options[0]->value)) {
-                    // reference to class
-                    $property['items']['$ref'] = (new Reference($this->options[0]->value))->jsonSerialize();
-                    return $property;
-                }
-
-                $property['items']['type'] = $this->options[0]->value->value;
-            } else {
-                $property['items']['anyOf'] = $this->options->jsonSerialize();
-            }
+        } elseif ($typesCount === 1) {
+            $property = \array_merge($property, $this->propertyTypeToDefinition($this->types[0]));
         }
 
         return $property;
@@ -95,16 +52,61 @@ final class Property implements \JsonSerializable
     public function getDependencies(): array
     {
         $dependencies = [];
-        foreach ($this->options->getOptions() as $option) {
-            if (\is_string($option->value)) {
-                $dependencies[] = $option->value;
+        foreach ($this->types as $type) {
+            if (\is_string($type->type)) {
+                $dependencies[] = $type->type;
+            }
+            if ($type->type === Type::Array && $type->collectionTypes !== null && $type->collectionTypes !== []) {
+                foreach ($type->collectionTypes as $collectionType) {
+                    if (\is_string($collectionType->type)) {
+                        $dependencies[] = $collectionType->type;
+                    }
+                }
             }
         }
 
-        if (\is_string($this->type)) {
-            $dependencies[] = $this->type;
+        return $dependencies;
+    }
+
+    protected function propertyTypeToDefinition(PropertyType $propertyType): array
+    {
+        $property = [];
+
+        if ($propertyType->type instanceof Type) {
+            $property['type'] = $propertyType->type->value;
+            if ($propertyType->enum !== null) {
+                $property['enum'] = $propertyType->enum;
+            }
+            if ($propertyType->type === Type::Array && $propertyType->collectionTypes !== null && $propertyType->collectionTypes !== []) {
+                $collectionTypeCount = \count($propertyType->collectionTypes);
+                if ($collectionTypeCount > 1) {
+                    foreach ($propertyType->collectionTypes as $collectionType) {
+                        if ($collectionType->type instanceof Type) {
+                            $schemaType = ['type' => $collectionType->type->value];
+                            if ($collectionType->enum !== null) {
+                                $schemaType['enum'] = $collectionType->enum;
+                            }
+                            $property['items']['anyOf'][] = $schemaType;
+                        } else {
+                            $property['items']['anyOf'][] = ['$ref' => (new Reference($collectionType->type))->jsonSerialize()];
+                        }
+                    }
+                } elseif ($collectionTypeCount === 1) {
+                    $collectionType = $propertyType->collectionTypes[0];
+                    if ($collectionType->type instanceof Type) {
+                        $property['items'] = ['type' => $collectionType->type->value];
+                        if ($collectionType->enum !== null) {
+                            $property['items']['enum'] = $collectionType->enum;
+                        }
+                    } else {
+                        $property['items'] = ['$ref' => (new Reference($collectionType->type))->jsonSerialize()];
+                    }
+                }
+            }
+        } else {
+            $property['$ref'] = (new Reference($propertyType->type))->jsonSerialize();
         }
 
-        return $dependencies;
+        return $property;
     }
 }

--- a/src/Schema/PropertyType.php
+++ b/src/Schema/PropertyType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\JsonSchemaGenerator\Schema;
+
+final class PropertyType
+{
+    /**
+     * @param class-string|Type $type
+     * @param list<int|string>|null $enum
+     * @param list<PropertyType>|null $collectionTypes
+     */
+    public function __construct(
+        public readonly string|Type $type,
+        public readonly ?array $enum = null,
+        public readonly ?array $collectionTypes = null,
+    ) {}
+}

--- a/src/Schema/Type.php
+++ b/src/Schema/Type.php
@@ -14,7 +14,6 @@ enum Type: string
     case Array = 'array';
     case Null = 'null';
     case Union = 'union';
-    case Enum = 'enum';
 
     public static function fromBuiltIn(string $type): self
     {

--- a/tests/Unit/Fixture/Actor.php
+++ b/tests/Unit/Fixture/Actor.php
@@ -9,15 +9,21 @@ use Spiral\JsonSchemaGenerator\Attribute\Field;
 final class Actor
 {
     public function __construct(
+        #[Field(title: 'Name', description: 'The name of the actor')]
         public readonly string $name,
+        #[Field(title: 'Age', description: 'The age of the actor')]
         public readonly int $age,
         #[Field(title: 'Biography', description: 'The biography of the actor')]
         public readonly ?string $bio = null,
+
         /**
-         * @var list<Movie>
+         * @var list<Movie|Series>|null
          */
-        public readonly array $movies = [],
+        #[Field(title: 'Filmography', description: 'List of movies and series featuring the actor')]
+        public readonly ?array $filmography = null,
         #[Field(title: 'Best Movie', description: 'The best movie of the actor')]
         public readonly ?Movie $bestMovie = null,
+        #[Field(title: 'Best Series', description: 'The most prominent series of the actor')]
+        public readonly ?Series $bestSeries = null,
     ) {}
 }

--- a/tests/Unit/Fixture/FlexibleValue.php
+++ b/tests/Unit/Fixture/FlexibleValue.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\JsonSchemaGenerator\Tests\Unit\Fixture;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final class FlexibleValue
+{
+    public function __construct(
+        #[Field(title: 'Value', description: 'Can be either string or integer')]
+        public readonly string|int $value,
+        #[Field(title: 'Optional Flag', description: 'Boolean or null')]
+        public readonly bool|null $flag = null,
+        #[Field(title: 'Flexible Field', description: 'Can be string, int, or null')]
+        public readonly string|int|null $flex = null,
+    ) {}
+}

--- a/tests/Unit/Fixture/Series.php
+++ b/tests/Unit/Fixture/Series.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\JsonSchemaGenerator\Tests\Unit\Fixture;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+use Spiral\JsonSchemaGenerator\Schema\Format;
+
+final class Series
+{
+    public function __construct(
+        #[Field(title: 'Title', description: 'The title of the series')]
+        public readonly string $title,
+        #[Field(title: 'First Air Year', description: 'The year the series first aired')]
+        public readonly int $firstAirYear,
+        #[Field(title: 'Description', description: 'The description of the series')]
+        public readonly ?string $description = null,
+        #[Field(title: 'Creator', description: 'The creator or showrunner of the series')]
+        public readonly ?string $creator = null,
+        #[Field(title: 'Series Status', description: 'The current status of the series')]
+        public readonly ?SeriesStatus $status = null,
+        #[Field(title: 'First Air Date', description: 'The original release date of the series', format: Format::Date)]
+        public readonly ?string $firstAirDate = null,
+        #[Field(title: 'Last Air Date', description: 'The most recent air date of the series', format: Format::Date)]
+        public readonly ?string $lastAirDate = null,
+        #[Field(title: 'Seasons', description: 'Number of seasons released')]
+        public readonly ?int $seasons = null,
+    ) {}
+}

--- a/tests/Unit/Fixture/SeriesStatus.php
+++ b/tests/Unit/Fixture/SeriesStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\JsonSchemaGenerator\Tests\Unit\Fixture;
+
+enum SeriesStatus: string
+{
+    case Airing = 'Airing';
+    case Ended = 'Ended';
+    case Canceled = 'Canceled';
+    case Upcoming = 'Upcoming';
+    case Hiatus = 'Hiatus';
+}

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -32,22 +32,19 @@ final class GeneratorTest extends TestCase
                     'description'   => [
                         'title'       => 'Description',
                         'description' => 'The description of the movie',
-                        'type'        => 'string',
+                        'type'        => ['string', 'null'],
                     ],
                     'director'      => [
-                        'type' => 'string',
+                        'type' => ['string', 'null'],
                     ],
                     'releaseStatus' => [
                         'title'       => 'Release Status',
                         'description' => 'The release status of the movie',
-                        'allOf'       => [
-                            [
-                                '$ref' => '#/definitions/ReleaseStatus',
-                            ],
-                        ],
+                        'type'        => ['string', 'null'],
+                        'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                     ],
                     'releaseDate'      => [
-                        'type' => 'string',
+                        'type' => ['string', 'null'],
                         'format' => 'date',
                         'title' => 'Release date',
                         'description' => 'The release date of the movie',
@@ -56,20 +53,6 @@ final class GeneratorTest extends TestCase
                 'required'    => [
                     'title',
                     'year',
-                ],
-                'definitions' => [
-                    'ReleaseStatus' => [
-                        'title' => 'ReleaseStatus',
-                        'type'  => 'string',
-                        'enum'  => [
-                            'Released',
-                            'Rumored',
-                            'Post Production',
-                            'In Production',
-                            'Planned',
-                            'Canceled',
-                        ],
-                    ],
                 ],
             ],
             $schema->jsonSerialize(),
@@ -93,7 +76,7 @@ final class GeneratorTest extends TestCase
                     'bio'       => [
                         'title'       => 'Biography',
                         'description' => 'The biography of the actor',
-                        'type'        => 'string',
+                        'type'        => ['string', 'null'],
                     ],
                     'movies'    => [
                         'type'  => 'array',
@@ -105,9 +88,12 @@ final class GeneratorTest extends TestCase
                     'bestMovie' => [
                         'title'       => 'Best Movie',
                         'description' => 'The best movie of the actor',
-                        'allOf'       => [
+                        'oneOf'       => [
                             [
                                 '$ref' => '#/definitions/Movie',
+                            ],
+                            [
+                                'type' => 'null',
                             ],
                         ],
                     ],
@@ -134,42 +120,27 @@ final class GeneratorTest extends TestCase
                             'description'   => [
                                 'title'       => 'Description',
                                 'description' => 'The description of the movie',
-                                'type'        => 'string',
+                                'type'        => ['string', 'null'],
                             ],
                             'director'      => [
-                                'type' => 'string',
-                            ],
-                            'releaseStatus' => [
-                                'title'       => 'Release Status',
-                                'description' => 'The release status of the movie',
-                                'allOf'       => [
-                                    [
-                                        '$ref' => '#/definitions/ReleaseStatus',
-                                    ],
-                                ],
+                                'type' => ['string', 'null'],
                             ],
                             'releaseDate'      => [
-                                'type' => 'string',
+                                'type' => ['string', 'null'],
                                 'format' => 'date',
                                 'title' => 'Release date',
                                 'description' => 'The release date of the movie',
+                            ],
+                            'releaseStatus'    => [
+                                'title' => 'Release Status',
+                                'description' => 'The release status of the movie',
+                                'type' => ['string', 'null'],
+                                'enum' => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                             ],
                         ],
                         'required'   => [
                             'title',
                             'year',
-                        ],
-                    ],
-                    'ReleaseStatus' => [
-                        'title' => 'ReleaseStatus',
-                        'type'  => 'string',
-                        'enum'  => [
-                            'Released',
-                            'Rumored',
-                            'Post Production',
-                            'In Production',
-                            'Planned',
-                            'Canceled',
                         ],
                     ],
                 ],

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -7,6 +7,7 @@ namespace Spiral\JsonSchemaGenerator\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Spiral\JsonSchemaGenerator\Generator;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Actor;
+use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\FlexibleValue;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
 
 final class GeneratorTest extends TestCase
@@ -18,7 +19,8 @@ final class GeneratorTest extends TestCase
 
         $this->assertEquals(
             [
-                'properties'  => [
+                'type' => 'object',
+                'properties' => [
                     'title'         => [
                         'title'       => 'Title',
                         'description' => 'The title of the movie',
@@ -32,21 +34,37 @@ final class GeneratorTest extends TestCase
                     'description'   => [
                         'title'       => 'Description',
                         'description' => 'The description of the movie',
-                        'type'        => ['string', 'null'],
+                        'oneOf'       => [
+                            ['type' => 'null'],
+                            ['type' => 'string'],
+                        ],
                     ],
                     'director'      => [
-                        'type' => ['string', 'null'],
+                        'oneOf' => [
+                            ['type' => 'null'],
+                            ['type' => 'string'],
+                        ],
                     ],
                     'releaseStatus' => [
                         'title'       => 'Release Status',
                         'description' => 'The release status of the movie',
-                        'type'        => ['string', 'null'],
-                        'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+                        'oneOf'       => [
+                            [
+                                'type' => 'null',
+                            ],
+                            [
+                                'type' => 'string',
+                                'enum' => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+                            ],
+                        ],
                     ],
                     'releaseDate'      => [
-                        'type' => ['string', 'null'],
-                        'format' => 'date',
-                        'title' => 'Release date',
+                        'oneOf'       => [
+                            ['type' => 'null'],
+                            ['type' => 'string'],
+                        ],
+                        'format'      => 'date',
+                        'title'       => 'Release date',
                         'description' => 'The release date of the movie',
                     ],
                 ],
@@ -66,84 +84,240 @@ final class GeneratorTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties'  => [
-                    'name'      => [
-                        'type' => 'string',
+                    'name' => [
+                        'type'        => 'string',
+                        'title'       => 'Name',
+                        'description' => 'The name of the actor',
                     ],
-                    'age'       => [
-                        'type' => 'integer',
+                    'age' => [
+                        'type'        => 'integer',
+                        'title'       => 'Age',
+                        'description' => 'The age of the actor',
                     ],
-                    'bio'       => [
+                    'bio' => [
                         'title'       => 'Biography',
                         'description' => 'The biography of the actor',
-                        'type'        => ['string', 'null'],
-                    ],
-                    'movies'    => [
-                        'type'  => 'array',
-                        'items' => [
-                            '$ref' => '#/definitions/Movie',
+                        'oneOf'       => [
+                            ['type' => 'null'],
+                            ['type' => 'string'],
                         ],
-                        'default' => [],
+                    ],
+                    'filmography' => [
+                        'title'       => 'Filmography',
+                        'description' => 'List of movies and series featuring the actor',
+                        'oneOf'       => [
+                            ['type' => 'null'],
+                            [
+                                'type'  => 'array',
+                                'items' => [
+                                    'anyOf' => [
+                                        ['$ref' => '#/definitions/Movie'],
+                                        ['$ref' => '#/definitions/Series'],
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                     'bestMovie' => [
                         'title'       => 'Best Movie',
                         'description' => 'The best movie of the actor',
                         'oneOf'       => [
-                            [
-                                '$ref' => '#/definitions/Movie',
-                            ],
-                            [
-                                'type' => 'null',
-                            ],
+                            ['type' => 'null'],
+                            ['$ref' => '#/definitions/Movie'],
+                        ],
+                    ],
+                    'bestSeries' => [
+                        'title'       => 'Best Series',
+                        'description' => 'The most prominent series of the actor',
+                        'oneOf'       => [
+                            ['type' => 'null'],
+                            ['$ref' => '#/definitions/Series'],
                         ],
                     ],
                 ],
-                'required'    => [
+                'required' => [
                     'name',
                     'age',
                 ],
                 'definitions' => [
-                    'Movie'         => [
+                    'Movie' => [
                         'title'      => 'Movie',
                         'type'       => 'object',
                         'properties' => [
-                            'title'         => [
+                            'title' => [
                                 'title'       => 'Title',
                                 'description' => 'The title of the movie',
                                 'type'        => 'string',
                             ],
-                            'year'          => [
+                            'year' => [
                                 'title'       => 'Year',
                                 'description' => 'The year of the movie',
                                 'type'        => 'integer',
                             ],
-                            'description'   => [
+                            'description' => [
                                 'title'       => 'Description',
                                 'description' => 'The description of the movie',
-                                'type'        => ['string', 'null'],
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
                             ],
-                            'director'      => [
-                                'type' => ['string', 'null'],
+                            'director' => [
+                                'oneOf' => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
                             ],
-                            'releaseDate'      => [
-                                'type' => ['string', 'null'],
-                                'format' => 'date',
-                                'title' => 'Release date',
+                            'releaseDate' => [
+                                'title'       => 'Release date',
                                 'description' => 'The release date of the movie',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
+                                'format' => 'date',
                             ],
-                            'releaseStatus'    => [
-                                'title' => 'Release Status',
+                            'releaseStatus' => [
+                                'title'       => 'Release Status',
                                 'description' => 'The release status of the movie',
-                                'type' => ['string', 'null'],
-                                'enum' => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    [
+                                        'type' => 'string',
+                                        'enum' => [
+                                            'Released',
+                                            'Rumored',
+                                            'Post Production',
+                                            'In Production',
+                                            'Planned',
+                                            'Canceled',
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                        'required'   => [
-                            'title',
-                            'year',
+                        'required' => ['title', 'year'],
+                    ],
+                    'Series' => [
+                        'title'      => 'Series',
+                        'type'       => 'object',
+                        'properties' => [
+                            'title' => [
+                                'title'       => 'Title',
+                                'description' => 'The title of the series',
+                                'type'        => 'string',
+                            ],
+                            'firstAirYear' => [
+                                'title'       => 'First Air Year',
+                                'description' => 'The year the series first aired',
+                                'type'        => 'integer',
+                            ],
+                            'description' => [
+                                'title'       => 'Description',
+                                'description' => 'The description of the series',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
+                            ],
+                            'creator' => [
+                                'title'       => 'Creator',
+                                'description' => 'The creator or showrunner of the series',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
+                            ],
+                            'status' => [
+                                'title'       => 'Series Status',
+                                'description' => 'The current status of the series',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    [
+                                        'type' => 'string',
+                                        'enum' => [
+                                            'Airing',
+                                            'Ended',
+                                            'Canceled',
+                                            'Upcoming',
+                                            'Hiatus',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'firstAirDate' => [
+                                'title'       => 'First Air Date',
+                                'description' => 'The original release date of the series',
+                                'format'      => 'date',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
+                            ],
+                            'lastAirDate' => [
+                                'title'       => 'Last Air Date',
+                                'description' => 'The most recent air date of the series',
+                                'format'      => 'date',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'string'],
+                                ],
+                            ],
+                            'seasons' => [
+                                'title'       => 'Seasons',
+                                'description' => 'Number of seasons released',
+                                'oneOf'       => [
+                                    ['type' => 'null'],
+                                    ['type' => 'integer'],
+                                ],
+                            ],
+                        ],
+                        'required' => ['title', 'firstAirYear'],
+                    ],
+                ],
+            ],
+            $schema->jsonSerialize(),
+        );
+    }
+
+    public function testGenerateFlexibleValue(): void
+    {
+        $generator = new Generator();
+        $schema = $generator->generate(FlexibleValue::class);
+
+        $this->assertEquals(
+            [
+                'type' => 'object',
+                'properties' => [
+                    'value' => [
+                        'title' => 'Value',
+                        'description' => 'Can be either string or integer',
+                        'oneOf' => [
+                            ['type' => 'string'],
+                            ['type' => 'integer'],
+                        ],
+                    ],
+                    'flag' => [
+                        'title' => 'Optional Flag',
+                        'description' => 'Boolean or null',
+                        'oneOf' => [
+                            ['type' => 'null'],
+                            ['type' => 'boolean'],
+                        ],
+                    ],
+                    'flex' => [
+                        'title' => 'Flexible Field',
+                        'description' => 'Can be string, int, or null',
+                        'oneOf' => [
+                            ['type' => 'null'],
+                            ['type' => 'string'],
+                            ['type' => 'integer'],
                         ],
                     ],
                 ],
+                'required' => ['value'],
             ],
             $schema->jsonSerialize(),
         );

--- a/tests/Unit/Parser/ClassParserTest.php
+++ b/tests/Unit/Parser/ClassParserTest.php
@@ -7,6 +7,7 @@ namespace Spiral\JsonSchemaGenerator\Tests\Unit\Parser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Spiral\JsonSchemaGenerator\Parser\ClassParser;
+use Spiral\JsonSchemaGenerator\Parser\SimpleType;
 use Spiral\JsonSchemaGenerator\Schema\Type;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\ReleaseStatus;
@@ -25,7 +26,7 @@ final class ClassParserTest extends TestCase
                  */
                 public array $collection;
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class {
@@ -34,7 +35,7 @@ final class ClassParserTest extends TestCase
                  */
                 public array $collection;
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class {
@@ -43,7 +44,7 @@ final class ClassParserTest extends TestCase
                  */
                 public array $collection;
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class {
@@ -52,7 +53,7 @@ final class ClassParserTest extends TestCase
                  */
                 public array $collection;
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -63,7 +64,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -74,7 +75,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -85,7 +86,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -96,7 +97,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -107,7 +108,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -118,7 +119,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -129,7 +130,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
         yield [
             new class([]) {
@@ -140,7 +141,7 @@ final class ClassParserTest extends TestCase
                     public array $collection,
                 ) {}
             },
-            [new \Spiral\JsonSchemaGenerator\Parser\Type(Movie::class, false, false)],
+            [new SimpleType(Movie::class, false)],
         ];
     }
 
@@ -165,45 +166,41 @@ final class ClassParserTest extends TestCase
         $properties = $parser->getProperties();
 
         $this->assertSame('title', $properties[0]->getName());
-        $this->assertSame(Type::String, $properties[0]->getType()->getName());
-        $this->assertTrue($properties[0]->getType()->isBuiltin());
+        $this->assertCount(1, $properties[0]->getType()->types);
+        $this->assertSame(Type::String, $properties[0]->getType()->types[0]->getName());
         $this->assertFalse($properties[0]->getType()->allowsNull());
-        $this->assertFalse($properties[0]->isCollection());
+        $this->assertFalse($properties[0]->getType()->types[0]->isCollection());
         $this->assertFalse($properties[0]->hasDefaultValue());
 
         $this->assertSame('year', $properties[1]->getName());
-        $this->assertSame(Type::Integer, $properties[1]->getType()->getName());
-        $this->assertTrue($properties[1]->getType()->isBuiltin());
+        $this->assertSame(Type::Integer, $properties[1]->getType()->types[0]->getName());
         $this->assertFalse($properties[1]->getType()->allowsNull());
-        $this->assertFalse($properties[1]->isCollection());
+        $this->assertFalse($properties[1]->getType()->types[0]->isCollection());
         $this->assertFalse($properties[1]->hasDefaultValue());
 
         $this->assertSame('description', $properties[2]->getName());
-        $this->assertSame(Type::String, $properties[2]->getType()->getName());
-        $this->assertTrue($properties[2]->getType()->isBuiltin());
+        $this->assertSame(Type::String, $properties[2]->getType()->types[1]->getName());
         $this->assertTrue($properties[2]->getType()->allowsNull());
-        $this->assertFalse($properties[2]->isCollection());
+        $this->assertFalse($properties[2]->getType()->types[0]->isCollection());
         $this->assertTrue($properties[2]->hasDefaultValue());
         $this->assertNull($properties[2]->getDefaultValue());
 
         $this->assertSame('director', $properties[3]->getName());
-        $this->assertSame(Type::String, $properties[3]->getType()->getName());
-        $this->assertTrue($properties[3]->getType()->isBuiltin());
+        $this->assertSame(Type::String, $properties[3]->getType()->types[1]->getName());
         $this->assertTrue($properties[3]->getType()->allowsNull());
-        $this->assertFalse($properties[3]->isCollection());
+        $this->assertFalse($properties[3]->getType()->types[0]->isCollection());
         $this->assertTrue($properties[3]->hasDefaultValue());
         $this->assertNull($properties[3]->getDefaultValue());
 
         $this->assertSame('releaseStatus', $properties[4]->getName());
-        $this->assertSame(Type::String, $properties[4]->getType()->getName());
-        $this->assertTrue($properties[4]->getType()->isEnum());
+        $this->assertSame(Type::String, $properties[4]->getType()->types[1]->getName());
+        $this->assertTrue($properties[4]->getType()->types[1]->isEnum());
         $this->assertEquals(
             ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
-            $properties[4]->getType()->getEnumValues(),
+            $properties[4]->getType()->types[1]->getEnumValues(),
         );
-        $this->assertTrue($properties[4]->getType()->isBuiltin());
         $this->assertTrue($properties[4]->getType()->allowsNull());
-        $this->assertFalse($properties[4]->isCollection());
+        $this->assertFalse($properties[4]->getType()->types[1]->isCollection());
         $this->assertTrue($properties[4]->hasDefaultValue());
         $this->assertNull($properties[4]->getDefaultValue());
     }
@@ -218,9 +215,9 @@ final class ClassParserTest extends TestCase
     }
 
     #[DataProvider('collectionsDataProvider')]
-    public function testGetPropertyCollectionTypes(object $class, array $expected): void
+    public function testGetPropertyCollectionTypes(object $class, ?array $expected): void
     {
         $parser = new ClassParser($class::class);
-        $this->assertEquals($expected, $parser->getProperties()[0]->getCollectionValueTypes());
+        $this->assertEquals($expected, $parser->getProperties()[0]->getType()->types[0]->getCollectionType()?->types);
     }
 }

--- a/tests/Unit/Parser/ClassParserTest.php
+++ b/tests/Unit/Parser/ClassParserTest.php
@@ -6,7 +6,6 @@ namespace Spiral\JsonSchemaGenerator\Tests\Unit\Parser;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Spiral\JsonSchemaGenerator\Exception\GeneratorException;
 use Spiral\JsonSchemaGenerator\Parser\ClassParser;
 use Spiral\JsonSchemaGenerator\Schema\Type;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
@@ -196,8 +195,13 @@ final class ClassParserTest extends TestCase
         $this->assertNull($properties[3]->getDefaultValue());
 
         $this->assertSame('releaseStatus', $properties[4]->getName());
-        $this->assertSame(ReleaseStatus::class, $properties[4]->getType()->getName());
-        $this->assertFalse($properties[4]->getType()->isBuiltin());
+        $this->assertSame(Type::String, $properties[4]->getType()->getName());
+        $this->assertTrue($properties[4]->getType()->isEnum());
+        $this->assertEquals(
+            ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+            $properties[4]->getType()->getEnumValues(),
+        );
+        $this->assertTrue($properties[4]->getType()->isBuiltin());
         $this->assertTrue($properties[4]->getType()->allowsNull());
         $this->assertFalse($properties[4]->isCollection());
         $this->assertTrue($properties[4]->hasDefaultValue());
@@ -211,29 +215,6 @@ final class ClassParserTest extends TestCase
 
         $parser = new ClassParser(ReleaseStatus::class);
         $this->assertTrue($parser->isEnum());
-    }
-
-    public function testGetEnumValues(): void
-    {
-        $parser = new ClassParser(ReleaseStatus::class);
-        $this->assertSame(
-            [
-                'Released',
-                'Rumored',
-                'Post Production',
-                'In Production',
-                'Planned',
-                'Canceled',
-            ],
-            $parser->getEnumValues(),
-        );
-    }
-
-    public function testGetEnumValuesException(): void
-    {
-        $parser = new ClassParser(Movie::class);
-        $this->expectException(GeneratorException::class);
-        $parser->getEnumValues();
     }
 
     #[DataProvider('collectionsDataProvider')]

--- a/tests/Unit/Parser/PropertyTest.php
+++ b/tests/Unit/Parser/PropertyTest.php
@@ -7,8 +7,8 @@ namespace Spiral\JsonSchemaGenerator\Tests\Unit\Parser;
 use PHPUnit\Framework\TestCase;
 use Spiral\JsonSchemaGenerator\Attribute\Field;
 use Spiral\JsonSchemaGenerator\Parser\Property;
+use Spiral\JsonSchemaGenerator\Parser\SimpleType;
 use Spiral\JsonSchemaGenerator\Parser\Type;
-use Spiral\JsonSchemaGenerator\Parser\TypeInterface;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
 
 final class PropertyTest extends TestCase
@@ -16,9 +16,9 @@ final class PropertyTest extends TestCase
     public function testGetName(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'title'),
-            $this->createMock(TypeInterface::class),
-            false,
+            property: new \ReflectionProperty(class: Movie::class, property: 'title'),
+            type: new Type(types: []),
+            hasDefaultValue: false,
         );
 
         $this->assertSame('title', $property->getName());
@@ -27,30 +27,30 @@ final class PropertyTest extends TestCase
     public function testFindAttribute(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'title'),
-            $this->createMock(TypeInterface::class),
-            false,
+            property: new \ReflectionProperty(class: Movie::class, property: 'title'),
+            type: new Type(types: []),
+            hasDefaultValue: false,
         );
 
         $this->assertEquals(
             new Field(title: 'Title', description: 'The title of the movie'),
-            $property->findAttribute(Field::class),
+            $property->findAttribute(name: Field::class),
         );
     }
 
     public function testHasDefaultValue(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            true,
+            property: new \ReflectionProperty(Movie::class, 'description'),
+            type: new Type([]),
+            hasDefaultValue: true,
         );
         $this->assertTrue($property->hasDefaultValue());
 
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            false,
+            property: new \ReflectionProperty(Movie::class, 'description'),
+            type: new Type([]),
+            hasDefaultValue: false,
         );
         $this->assertFalse($property->hasDefaultValue());
     }
@@ -58,17 +58,17 @@ final class PropertyTest extends TestCase
     public function testGetDefaultValue(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            true,
+            property: new \ReflectionProperty(Movie::class, 'description'),
+            type: new Type([]),
+            hasDefaultValue: true,
         );
         $this->assertNull($property->getDefaultValue());
 
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            true,
-            'foo',
+            property: new \ReflectionProperty(Movie::class, 'description'),
+            type: new Type(types: []),
+            hasDefaultValue: true,
+            defaultValue: 'foo',
         );
         $this->assertSame('foo', $property->getDefaultValue());
     }
@@ -76,53 +76,35 @@ final class PropertyTest extends TestCase
     public function testIsCollection(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            new Type('string', true, false),
-            true,
+            property: new \ReflectionProperty(class: Movie::class, property: 'description'),
+            type: new Type(types: [new SimpleType(name: 'string', builtin: true)]),
+            hasDefaultValue: true,
         );
-        $this->assertFalse($property->isCollection());
+        $this->assertFalse($property->getType()->types[0]->isCollection());
 
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            new Type(Movie::class, false, false),
-            true,
+            property: new \ReflectionProperty(Movie::class, 'description'),
+            type: new Type(types: [new SimpleType(name: Movie::class, builtin: false)]),
+            hasDefaultValue: true,
         );
-        $this->assertFalse($property->isCollection());
+        $this->assertFalse($property->getType()->types[0]->isCollection());
 
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            new Type('array', true, false),
-            true,
+            property: new \ReflectionProperty(class: Movie::class, property: 'description'),
+            type: new Type(types: [new SimpleType(name: 'array', builtin: true, collectionType: new Type(types: [new SimpleType(name: 'string', builtin: true)]))]),
+            hasDefaultValue: true,
         );
-        $this->assertTrue($property->isCollection());
-    }
-
-    public function testGetCollectionValueTypes(): void
-    {
-        $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            true,
-        );
-        $this->assertSame([], $property->getCollectionValueTypes());
-
-        $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            $this->createMock(TypeInterface::class),
-            true,
-            null,
-            [new Type(Movie::class, false, false)],
-        );
-        $this->assertEquals([new Type(Movie::class, false, false)], $property->getCollectionValueTypes());
+        $this->assertTrue($property->getType()->types[0]->isCollection());
+        $this->assertEquals('string', $property->getType()->types[0]->getCollectionType()?->types[0]?->getName()->value);
     }
 
     public function testGetType(): void
     {
         $property = new Property(
-            new \ReflectionProperty(Movie::class, 'description'),
-            new Type(Movie::class, false, false),
-            true,
+            property: new \ReflectionProperty(class: Movie::class, property: 'description'),
+            type: new Type(types: [new SimpleType(name: Movie::class, builtin: false)]),
+            hasDefaultValue: true,
         );
-        $this->assertEquals(new Type(Movie::class, false, false), $property->getType());
+        $this->assertEquals(new SimpleType(name: Movie::class, builtin: false), $property->getType()->types[0]);
     }
 }

--- a/tests/Unit/Parser/TypeTest.php
+++ b/tests/Unit/Parser/TypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\JsonSchemaGenerator\Tests\Unit\Parser;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\JsonSchemaGenerator\Parser\SimpleType;
 use Spiral\JsonSchemaGenerator\Parser\Type;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
 
@@ -12,28 +13,28 @@ final class TypeTest extends TestCase
 {
     public function testGetName(): void
     {
-        $type = new Type('string', true, false);
+        $type = new SimpleType(name: 'string', builtin: true);
         $this->assertSame(\Spiral\JsonSchemaGenerator\Schema\Type::String, $type->getName());
 
-        $type = new Type(Movie::class, false, false);
+        $type = new SimpleType(name: Movie::class, builtin: false);
         $this->assertSame(Movie::class, $type->getName());
     }
 
     public function testIsBuiltin(): void
     {
-        $type = new Type('string', true, false);
+        $type = new SimpleType(name: 'string', builtin: true);
         $this->assertTrue($type->isBuiltin());
 
-        $type = new Type(Movie::class, false, false);
+        $type = new SimpleType(name: Movie::class, builtin: false);
         $this->assertFalse($type->isBuiltin());
     }
 
     public function testAllowsNull(): void
     {
-        $type = new Type('string', true, true);
+        $type = new Type(types: [new SimpleType(name: 'null', builtin: true), new SimpleType(name: 'string', builtin: true)]);
         $this->assertTrue($type->allowsNull());
 
-        $type = new Type(Movie::class, false, false);
+        $type = new Type(types: [new SimpleType(name: Movie::class, builtin: false)]);
         $this->assertFalse($type->allowsNull());
     }
 }

--- a/tests/Unit/Schema/DefinitionTest.php
+++ b/tests/Unit/Schema/DefinitionTest.php
@@ -27,10 +27,12 @@ final class DefinitionTest extends TestCase
                     required: true,
                 ),
                 'status' => new Property(
-                    type: ReleaseStatus::class,
+                    type: Type::String,
                     title: 'Status',
                     description: 'Status of the movie',
                     required: true,
+                    allowsNull: true,
+                    enum: ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                 ),
             ],
         );
@@ -39,18 +41,15 @@ final class DefinitionTest extends TestCase
             'type' => 'object',
             'properties' => [
                 'title' => [
-                    'title' => 'Title',
+                    'title'       => 'Title',
                     'description' => 'Title of the movie',
-                    'type' => 'string',
+                    'type'        => 'string',
                 ],
                 'status' => [
-                    'title' => 'Status',
+                    'title'       => 'Status',
                     'description' => 'Status of the movie',
-                    'allOf' => [
-                        [
-                            '$ref' => '#/definitions/ReleaseStatus',
-                        ],
-                    ],
+                    'type'        => ['string', 'null'],
+                    'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                 ],
             ],
             'required' => [

--- a/tests/Unit/Schema/DefinitionTest.php
+++ b/tests/Unit/Schema/DefinitionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Spiral\JsonSchemaGenerator\Exception\DefinitionException;
 use Spiral\JsonSchemaGenerator\Schema\Definition;
 use Spiral\JsonSchemaGenerator\Schema\Property;
+use Spiral\JsonSchemaGenerator\Schema\PropertyType;
 use Spiral\JsonSchemaGenerator\Schema\Type;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\InvalidEnum;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
@@ -21,18 +22,16 @@ final class DefinitionTest extends TestCase
             type: Movie::class,
             properties: [
                 'title' => new Property(
-                    type: Type::String,
+                    types: [new PropertyType(type: Type::String)],
                     title: 'Title',
                     description: 'Title of the movie',
                     required: true,
                 ),
                 'status' => new Property(
-                    type: Type::String,
+                    types: [new PropertyType(type: Type::Null), new PropertyType(type: Type::String, enum: ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'])],
                     title: 'Status',
                     description: 'Status of the movie',
                     required: true,
-                    allowsNull: true,
-                    enum: ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
                 ),
             ],
         );
@@ -48,8 +47,13 @@ final class DefinitionTest extends TestCase
                 'status' => [
                     'title'       => 'Status',
                     'description' => 'Status of the movie',
-                    'type'        => ['string', 'null'],
-                    'enum'        => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+                    'oneOf'       => [
+                        ['type' => 'null'],
+                        [
+                            'type' => 'string',
+                            'enum' => ['Released', 'Rumored', 'Post Production', 'In Production', 'Planned', 'Canceled'],
+                        ],
+                    ],
                 ],
             ],
             'required' => [

--- a/tests/Unit/Schema/PropertyTest.php
+++ b/tests/Unit/Schema/PropertyTest.php
@@ -77,11 +77,7 @@ final class PropertyTest extends TestCase
         );
 
         $this->assertEquals([
-            'allOf' => [
-                [
-                    '$ref' => '#/definitions/Movie',
-                ],
-            ],
+            '$ref' =>  '#/definitions/Movie',
         ], $property->jsonSerialize());
     }
 

--- a/tests/Unit/Schema/PropertyTest.php
+++ b/tests/Unit/Schema/PropertyTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Spiral\JsonSchemaGenerator\Tests\Unit\Schema;
 
 use PHPUnit\Framework\TestCase;
-use Spiral\JsonSchemaGenerator\Exception\InvalidTypeException;
+use Spiral\JsonSchemaGenerator\Parser\SimpleType;
 use Spiral\JsonSchemaGenerator\Schema\Format;
 use Spiral\JsonSchemaGenerator\Schema\Property;
+use Spiral\JsonSchemaGenerator\Schema\PropertyType;
 use Spiral\JsonSchemaGenerator\Schema\Type;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Actor;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
@@ -16,14 +17,14 @@ final class PropertyTest extends TestCase
 {
     public function testPropertyOnlyRequiredParams(): void
     {
-        $property = new Property(type: Type::String);
+        $property = new Property(types: [new PropertyType(type: Type::String)]);
 
         $this->assertEquals(['type' => 'string'], $property->jsonSerialize());
     }
 
     public function testPropertyWithTitle(): void
     {
-        $property = new Property(type: Type::String, title: 'Some movie');
+        $property = new Property(types: [new PropertyType(type: Type::String)], title: 'Some movie');
 
         $this->assertEquals([
             'type' => 'string',
@@ -33,7 +34,7 @@ final class PropertyTest extends TestCase
 
     public function testPropertyWithDescription(): void
     {
-        $property = new Property(type: Type::String, description: 'Some description');
+        $property = new Property(types: [new PropertyType(type: Type::String)], description: 'Some description');
 
         $this->assertEquals([
             'type' => 'string',
@@ -43,7 +44,7 @@ final class PropertyTest extends TestCase
 
     public function testPropertyWithDefault(): void
     {
-        $property = new Property(type: Type::String, default: 'value');
+        $property = new Property(types: [new PropertyType(type: Type::String)], default: 'value');
 
         $this->assertEquals([
             'type' => 'string',
@@ -54,12 +55,11 @@ final class PropertyTest extends TestCase
     public function testPropertyWithUnionType(): void
     {
         $property = new Property(
-            type: Type::Union,
-            options: [Movie::class, Actor::class],
+            types: [new PropertyType(type: Movie::class), new PropertyType(type: Actor::class)],
         );
 
         $this->assertEquals([
-            'anyOf' => [
+            'oneOf' => [
                 [
                     '$ref' => '#/definitions/Movie',
                 ],
@@ -73,7 +73,7 @@ final class PropertyTest extends TestCase
     public function testPropertyWithClassType(): void
     {
         $property = new Property(
-            type: Movie::class,
+            types: [new PropertyType(type: Movie::class)],
         );
 
         $this->assertEquals([
@@ -84,8 +84,7 @@ final class PropertyTest extends TestCase
     public function testPropertyWithArrayTypeSingleClassElem(): void
     {
         $property = new Property(
-            type: Type::Array,
-            options: [Movie::class],
+            types: [new PropertyType(type: Type::Array, collectionTypes: [new PropertyType(type: Movie::class)])],
             title: 'Some movie',
         );
 
@@ -101,8 +100,7 @@ final class PropertyTest extends TestCase
     public function testPropertyWithArrayTypeSingleScalarElem(): void
     {
         $property = new Property(
-            type: Type::Array,
-            options: [Type::String],
+            types: [new PropertyType(type: Type::Array, collectionTypes: [new PropertyType(type: Type::String)])],
             title: 'Some movie',
         );
 
@@ -118,8 +116,7 @@ final class PropertyTest extends TestCase
     public function testPropertyWithArrayTypeMultipleElems(): void
     {
         $property = new Property(
-            type: Type::Array,
-            options: [Movie::class, Type::String],
+            types: [new PropertyType(type: Type::Array, collectionTypes: [new PropertyType(type: Movie::class), new PropertyType(type: Type::String)])],
             title: 'Some movie',
         );
 
@@ -141,13 +138,13 @@ final class PropertyTest extends TestCase
 
     public function testInvalidTypeException(): void
     {
-        $this->expectException(InvalidTypeException::class);
-        new Property(type: 'foo');
+        $this->expectException(\InvalidArgumentException::class);
+        new SimpleType(name: 'foo', builtin: true);
     }
 
     public function testPropertyWithFormat(): void
     {
-        $property = new Property(type: Type::String, title: 'Homepage', format: Format::Uri);
+        $property = new Property(types: [new PropertyType(type: Type::String)], title: 'Homepage', format: Format::Uri);
 
         $this->assertEquals([
             'type' => 'string',

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -247,11 +247,7 @@ final class SchemaTest extends TestCase
                 'properties' => [
                     'movie' => [
                         'title' => 'Some movie',
-                        'allOf' => [
-                            [
-                                '$ref' => '#/definitions/Movie',
-                            ],
-                        ],
+                        '$ref' => '#/definitions/Movie',
                     ],
                 ],
             ],

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -6,6 +6,7 @@ namespace Spiral\JsonSchemaGenerator\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\JsonSchemaGenerator\Schema;
+use Spiral\JsonSchemaGenerator\Schema\PropertyType;
 use Spiral\JsonSchemaGenerator\Tests\Unit\Fixture\Movie;
 
 final class SchemaTest extends TestCase
@@ -14,7 +15,7 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
 
-        $this->assertSame([], $schema->jsonSerialize());
+        $this->assertSame(['type' => 'object'], $schema->jsonSerialize());
     }
 
     public function testStringProperty(): void
@@ -23,7 +24,7 @@ final class SchemaTest extends TestCase
         $schema->addProperty(
             'name',
             new Schema\Property(
-                type: Schema\Type::String,
+                types: [new PropertyType(type: Schema\Type::String)],
                 title: 'Name',
                 description: 'Name of the user',
                 required: true,
@@ -32,6 +33,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'name' => [
                         'title' => 'Name',
@@ -51,9 +53,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'name',
-            new Schema\Property(
-                type: Schema\Type::String,
+            name: 'name',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::String)],
                 title: 'Name',
                 description: 'Name of the user',
                 required: true,
@@ -61,9 +63,9 @@ final class SchemaTest extends TestCase
         );
 
         $schema->addProperty(
-            'age',
-            new Schema\Property(
-                type: Schema\Type::Integer,
+            name: 'age',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Integer)],
                 title: 'Age',
                 description: 'Age of the user',
                 required: true,
@@ -71,9 +73,9 @@ final class SchemaTest extends TestCase
         );
 
         $schema->addProperty(
-            'height',
-            new Schema\Property(
-                type: Schema\Type::Number,
+            name: 'height',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Number)],
                 title: 'Height',
                 description: 'Height of the user',
                 required: true,
@@ -81,9 +83,9 @@ final class SchemaTest extends TestCase
         );
 
         $schema->addProperty(
-            'is_active',
-            new Schema\Property(
-                type: Schema\Type::Boolean,
+            name: 'is_active',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Boolean)],
                 title: 'Is Active',
                 description: 'Is the user active',
                 required: false,
@@ -92,6 +94,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'name'      => [
                         'title'       => 'Name',
@@ -128,10 +131,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'hobbies',
-            new Schema\Property(
-                type: Schema\Type::Array,
-                options: [Schema\Type::String],
+            name: 'hobbies',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Array, collectionTypes: [new PropertyType(type: Schema\Type::String)])],
                 title: 'Hobbies',
                 description: 'Hobbies of the user',
                 required: true,
@@ -140,6 +142,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'hobbies' => [
                         'type'        => 'array',
@@ -162,10 +165,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'hobbies',
-            new Schema\Property(
-                type: Schema\Type::Array,
-                options: [Schema\Type::String, Schema\Type::Number],
+            name: 'hobbies',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Array, collectionTypes: [new PropertyType(type: Schema\Type::String), new PropertyType(type: Schema\Type::Number)])],
                 title: 'Hobbies',
                 description: 'Hobbies of the user',
                 required: true,
@@ -174,6 +176,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'hobbies' => [
                         'type'        => 'array',
@@ -195,48 +198,13 @@ final class SchemaTest extends TestCase
         );
     }
 
-    public function testMixedProperty(): void
-    {
-        $schema = new Schema();
-        $schema->addProperty(
-            'hobbies',
-            new Schema\Property(
-                type: Schema\Type::Union,
-                options: [Schema\Type::String, Schema\Type::Number, Schema\Type::Boolean],
-                title: 'Some value',
-                description: 'Some random user value',
-                required: true,
-            ),
-        );
-
-        $this->assertEquals(
-            [
-                'properties' => [
-                    'hobbies' => [
-                        'title'       => 'Some value',
-                        'description' => 'Some random user value',
-                        'anyOf'       => [
-                            ['type' => 'string'],
-                            ['type' => 'number'],
-                            ['type' => 'boolean'],
-                        ],
-                    ],
-                ],
-                'required'   => [
-                    'hobbies',
-                ],
-            ],
-            $schema->jsonSerialize(),
-        );
-    }
-
     public function testClassProperty(): void
     {
         $schema = new Schema();
         $schema->addProperty(
-            'movie',
-            new Schema\Property(
-                type: Movie::class,
+            name: 'movie',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Movie::class)],
                 title: 'Some movie',
                 required: false,
             ),
@@ -244,6 +212,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'movie' => [
                         'title' => 'Some movie',
@@ -259,10 +228,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'movie',
-            new Schema\Property(
-                type: Schema\Type::Array,
-                options: [Movie::class],
+            name: 'movie',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Array, collectionTypes: [new PropertyType(type: Movie::class)])],
                 title: 'Some movie',
                 required: false,
             ),
@@ -270,6 +238,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'movie' => [
                         'title' => 'Some movie',
@@ -288,10 +257,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'movie',
-            new Schema\Property(
-                type: Schema\Type::Array,
-                options: [Movie::class, Schema\Type::String],
+            name: 'movie',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Array, collectionTypes: [new PropertyType(type: Movie::class), new PropertyType(type: Schema\Type::String)])],
                 title: 'Some movie',
                 required: false,
             ),
@@ -299,6 +267,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties' => [
                     'movie' => [
                         'title' => 'Some movie',
@@ -324,10 +293,9 @@ final class SchemaTest extends TestCase
     {
         $schema = new Schema();
         $schema->addProperty(
-            'movie',
-            new Schema\Property(
-                type: Schema\Type::Array,
-                options: [Movie::class, Schema\Type::String],
+            name: 'movie',
+            property: new Schema\Property(
+                types: [new PropertyType(type: Schema\Type::Array, collectionTypes: [new PropertyType(type: Movie::class), new PropertyType(type: Schema\Type::String)])],
                 title: 'Some movie',
                 required: false,
             ),
@@ -337,7 +305,7 @@ final class SchemaTest extends TestCase
             type: Movie::class,
             properties: [
                 'title' => new Schema\Property(
-                    type: Schema\Type::String,
+                    types: [new PropertyType(type: Schema\Type::String)],
                     title: 'Title',
                     description: 'Title of the movie',
                     required: true,
@@ -349,6 +317,7 @@ final class SchemaTest extends TestCase
 
         $this->assertEquals(
             [
+                'type' => 'object',
                 'properties'  => [
                     'movie' => [
                         'title' => 'Some movie',


### PR DESCRIPTION
?string - type: [string, null] not type: string

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️/❌
| Breaks BC?    | ✔️/❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️/❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
Issue: ?string field incorrectly mapped as non-nullable in JSON Schema
I attempted to generate a JSON Schema for the following DTO:

`final class CoutryDto
{
    #[Field(format: Format::DateTime)]
    public string $createdAt;
    #[Field(format: Format::DateTime)]
    public string $updatedAt;
    #[Field(default: null, format: Format::DateTime)]
    public ?string $deletedAt;

    public function __construct(
        public string $id,
        public ?string $alpha2,
        public ?string $alpha3,
        public ?int $geonameId,
        public ?int $feedcacheId,
        public string $name,
        DateTimeImmutable $createdAt,
        DateTimeImmutable $updatedAt,
        ?DateTimeImmutable $deletedAt,
    ) {
        $this->createdAt = $createdAt->format(DATE_RFC3339);
        $this->updatedAt = $updatedAt->format(DATE_RFC3339);
        $this->deletedAt = $deletedAt?->format(DATE_RFC3339);
    }
}`

Note: The $deletedAt property is explicitly typed as ?string and should be treated as nullable.

However, the generated schema incorrectly defines deletedAt as a non-nullable string:
`{
   "properties":{
      "createdAt":{
         "format":"date-time",
         "type":"string"
      },
      "updatedAt":{
         "format":"date-time",
         "type":"string"
      },
      "deletedAt":{
         "format":"date-time",
         "type":"string"
      },
      "id":{
         "format":"uuid",
         "type":"string"
      },
      "name":{
         "type":"string"
      },
      "patterns":{
         "type":"array",
         "items":{
            "$ref":"#/definitions/PatternUpdated"
         }
      }
   },
   "required":[
      "createdAt",
      "updatedAt",
      "id",
      "name",
      "patterns"
   ],
   "definitions":{
      "PatternUpdated":{
         "title":"PatternUpdated",
         "type":"object",
         "properties":{
            "id":{
               "type":"string"
            },
            "description":{
               "type":"string"
            }
         },
         "required":[
            "id",
            "description"
         ]
      }
   }
}`

When validating a CountryDto instance with deletedAt = null, the following error is returned:
`[
  {
    "property": "deletedAt",
    "pointer": "/deletedAt",
    "message": "NULL value found, but a string is required",
    "constraint": {
      "name": "type",
      "params": {
        "found": "NULL",
        "expected": "a string"
      }
    },
    "context": 1
  }
]`

While adding support for nullable properties in JSON Schema generation, several related issues were discovered and addressed:

✅ Added support for nullable enum types using ["string", "null"] representation

🛠️ Fixed incorrect usage of allOf for class-based properties — replaced with proper $ref or oneOf([$ref, null])

🚫 Removed deprecated type usages that triggered Psalm errors under Symfony 7.3

🧹 Improved compatibility and reduced warnings in modern environments

These changes improve both the correctness and compatibility of generated schemas and static analysis in modern Symfony setups.
